### PR TITLE
Change Room Number in Description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: "KITCTF"
 baseurl: ""
 url: "https://kitctf.de"
-description: "We are a group of students, computer security enthusiasts and CTF players mostly from the Karlsruhe Institute of Technology. If you are interested in hacking with us, write us at team@kitctf.de or come to our weekly meetings. We meet every Thursday at 7 pm in the computer science building (50.34), room 252."
+description: "We are a group of students, computer security enthusiasts and CTF players mostly from the Karlsruhe Institute of Technology. If you are interested in hacking with us, write us at team@kitctf.de or come to our weekly meetings. We meet every Thursday at 7 pm in the computer science building (50.34), room -120."
 
 github: kitctf
 twitter: KITCTF


### PR DESCRIPTION
Seems like google returned a wrong description and we didn't notice the room number was all wrong in the last commit. Well now we should have a correct description.

EDIT: Well opening the PR from vim went a bit wrong :P