### PR TITLE
Fix font-weighting

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -12,7 +12,6 @@ body {
   font-family: Helvetica, Arial, sans-serif;
   font-size: 16px;
   line-height: 1.5;
-  font-weight: 300;
   background-color: #fdfdfd;
 }
 


### PR DESCRIPTION
Firefox renders the font-weight very weird, as in bold text isn't bold.
Also code blocks are rendered more readable imo.