### PR TITLE
Fix liquid warning in feed.xml

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -8,7 +8,7 @@ layout: none
     <description>{{ site.description | xml_escape }}</description>
     <link>{{ site.url }}{{ site.baseurl }}/</link>
     <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml" />
-    {% assign posts = site.posts | where: 'excludeRSS', ! true%}
+    {% assign posts = site.posts | where_exp:"item", "item.excludeRSS != true" %}
     {% for post in posts limit:10 %}
       <item>
         <title>{{ post.title | xml_escape }}</title>


### PR DESCRIPTION
This also fixes the "problem" that a post with the front matter "excludeRSS: false" would *still* be excluded, because the original implementation effectively only checked whether a "excludeRSS" field existed *at all*.