### PR TITLE
Crypto talk

### DIFF
--- a/_posts/2023-02-23-elliptic_curve.md
+++ b/_posts/2023-02-23-elliptic_curve.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: "Talk: Elliptic Curves"
+categories: learning
+author: Benedikt, Liam
+---
+
+We look at curves that look like fish and do some maths to break some crypto. Benedikt shows us how.
+
+* Here are the [Slides](/talks/?2023-02-16-elliptic-curve)
+* Also hxp 2021 gipfel, kipfel, zipfel challenges to practice
+

--- a/talks/2023-02-16-elliptic-curve/slides.md
+++ b/talks/2023-02-16-elliptic-curve/slides.md
@@ -95,7 +95,7 @@ Elliptic Curve equation: $y^2 = x^3 + ax + b$
 
 ## ECDH:
 
-(Google ECDH and find a nice looking image)
+(Search for ECDH and find a nice looking image explanation or draw a CC image and insert it here)
 
 ---
 

--- a/talks/2023-02-16-elliptic-curve/slides.md
+++ b/talks/2023-02-16-elliptic-curve/slides.md
@@ -1,0 +1,114 @@
+
+# Introduction to Elliptic Curves
+
+---
+
+## Basics:
+- Primitives of asymmetric cryptography:
+    1. Key exchange
+    2. Encryption
+    3. Signatures
+- now over a different ring (new algebraic structure)
+
+---
+
+## Motivation:
+
+| Algorithm Family | Cryptosystems | Security <br> short term | Level <br> medium | (bit) <br> long term | <br>  | <br>  |
+|--|--|--|--|--|--|--|
+| Integer Factorization | RSA | 700 | 1024 | 3072 | 7680 | 15360 |
+| Discrete Logarithm ($\mathbb{Z}_{p^*}$) | DH, DSA, Elgamal | 700 | 1024 | 3072 | 7680 | 15360 |
+| Elliptic Curves | ECDH, ECDSA | 128 | 160 | 256 | 384 | 512 |
+| Symmetric Key | AES, 3DES | 64 | 80 | 128 | 192 | 256 |
+
+---
+
+## Motivation:
+
+Higher security levels for RSA etc. require computations over large numbers, many operations, very slow
+
+Goal: find cyclic group with hard DLP that allows for smaller key sizes and efficient computation
+
+<small>DLP -- Discrete Logarithm Problem</small>
+
+---
+
+## Geometric Interpretation:
+
+Elliptic Curve equation: $y^2 = x^3 + ax + b$
+
+![Elliptic Curve](https://c.m5w.de/uploads/e1e09d8b-db2c-4697-97f2-236190e83051.png)
+
+---
+
+## Geometric Interpretation:
+
+- Group: Generator point $G$, multiplication with natural number
+- x-axis symmetry
+- Multiplication over EC:
+    1. Find intersection with curve
+        a. For $2G$: tangent at point $G$
+        b. For $aG, a>2$: line through $G$ and $(a-1)G$
+    2. Flip y-coordinate
+
+---
+
+## Maths:
+
+- EC group over $\mathbb{Z}_p, p > 3$
+- Point $(x, y)$ on curve iff $y^2 \equiv x^3 + ax + b \mod p$, plus (imaginary) point at infinity $O$, $a,b \in \mathbb{Z}_p$ with $4a^3 + 27b^2 \not\equiv 0 \mod p$
+- Cyclic group:
+    1. set of elements (points on curve)
+    2. group operation fulfilling group laws
+
+---
+
+## Maths:
+
+- Group operation:
+    - Point addition and point doubling ($(x_1,y_1) + (x_2,y_2)$):
+        $x_3 \equiv s^2 -x_1 -x_2 \mod p$
+        $y_3 \equiv s (x_1 - x_3) -y_1 \mod p$
+        - $s = \frac{y_2-y_1}{x_2-x_1} \mod p$ (addition)
+        - $s = \frac{3x_1^2+a}{2y_1} \mod p$ (doubling)
+    - neutral element: "artificial" point at infinity $O$
+    - inverse: $-P = (x,-y)$ (x-coordinate flipped)
+
+---
+
+## Attributes:
+
+- mathematics necessary for reversing more complicated, less efficient -> smaller keys provide same security
+- similar structure to DL-problem, can still be broken with QC
+
+---
+
+## ECDH:
+
+- DL-Problem over EC: given $Q = aG$, finding $a$ is "hard"
+- ECDH:
+    1. choose curve with generator $G$
+    2. Alice and Bob choose and exchange $aG$ and $bG$, $a$ and $b$ are secret
+    3. Alice and Bob compute shared secret $(ab)G = a(bG) = b(aG)$
+
+---
+
+## ECDH:
+
+(Google ECDH and find a nice looking image)
+
+---
+
+## Further Topics:
+
+- ECDSA
+- Pairing based cryptography with EC
+- EC in `sagemath`
+
+---
+
+## Sources:
+
+- Elliptic Curves, Computerphile: https://www.youtube.com/watch?v=NF1pwjL9-DE
+- Einführung in die Elliptische-Kurven-Kryptografie (ECC), Lecture: https://www.youtube.com/watch?v=ikeA6SZ83W8
+

--- a/talks/index.html
+++ b/talks/index.html
@@ -46,6 +46,7 @@
     // - https://revealjs.com/config/
     Reveal.initialize({
         hash: true,
+        width: '80%',
 
         // Learn about plugins: https://revealjs.com/plugins/
         plugins: [RevealMarkdown, RevealHighlight, RevealNotes, RevealMath.MathJax2]

--- a/talks/index.html
+++ b/talks/index.html
@@ -29,6 +29,7 @@
 <script src="./reveal/plugin/notes/notes.js"></script>
 <script src="./reveal/plugin/markdown/markdown.js"></script>
 <script src="./reveal/plugin/highlight/highlight.js"></script>
+<script src="./reveal/plugin/math/math.js"></script>
 <script>
     const file = location.search.substring(1)
 
@@ -47,7 +48,7 @@
         hash: true,
 
         // Learn about plugins: https://revealjs.com/plugins/
-        plugins: [RevealMarkdown, RevealHighlight, RevealNotes]
+        plugins: [RevealMarkdown, RevealHighlight, RevealNotes, RevealMath.MathJax2]
     });
 </script>
 </body>


### PR DESCRIPTION
This fixes the issue with math rendering.

NOTE: We now fetch MathJax2.js from [jsdelivr](https://cdn.jsdelivr.net/npm/mathjax@2/).
This might be undesired; if so, we have to bundle it ourselves.
However this is also not ideal, because we would then have files with a total file size of ~60 megabyte in our git repo...

Somewhat okay solution would be to install/clone mathjax at build time using npm/bower/whatever so it is not stored in git.
With the default GitHub Pages we can not execute custom code as far as I understand, so we would have to switch our Pages build to one based on [workflows](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow).
We can do that as a follow up PR and just use the CDN for the time being.