### PR TITLE
Add proper redirects for links to external sites

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
 gem 'jekyll'
+gem 'jekyll-redirect-from'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,8 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
+    jekyll-redirect-from (0.16.0)
+      jekyll (>= 3.3, < 5.0)
     jekyll-sass-converter (3.0.0)
       sass-embedded (~> 1.54)
     jekyll-watch (2.2.1)
@@ -67,6 +69,7 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll
+  jekyll-redirect-from
 
 BUNDLED WITH
    2.2.24

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,8 @@ twitter: KITCTF
 # Build settings
 markdown: kramdown
 permalink: /:categories/:title
+plugins:
+  - jekyll-redirect-from
 
 # Authors
 authors:

--- a/_layouts/category_index.html
+++ b/_layouts/category_index.html
@@ -19,10 +19,10 @@ layout: default
       {% endif %}
     {% endfor %}
     {% unless sticky %}
-    {% if post.external_url %}
+    {% if post.redirect_to %}
       <li>
         <span class="post-date">{{ post.date | date: "%b %-d, %Y" }}</span>
-        <a class="post-link" href="{{ post.external_url}}">{{ post.title }}</a>
+        <a class="post-link" href="{{ post.redirect_to}}">{{ post.title }}</a>
       </li>
       {% else %}
       <li>

--- a/_posts/2021-11-16-crypto_warm_up.md
+++ b/_posts/2021-11-16-crypto_warm_up.md
@@ -1,6 +1,6 @@
 ---
 title: "ASIS CTF 2021: Crypto Warm up"
-external_url: "https://wachter-space.de/2021/11/16/asis_ctf_2021_writeup#crypto-warm-up"
+redirect_to: "https://wachter-space.de/2021/11/16/asis_ctf_2021_writeup#crypto-warm-up"
 categories: writeups
 ---
 

--- a/_posts/2021-11-16-factory.md
+++ b/_posts/2021-11-16-factory.md
@@ -1,6 +1,6 @@
 ---
 title: "ASIS CTF 2021: Factory"
-external_url: "https://wachter-space.de/2021/11/16/asis_ctf_2021_writeup#factory"
+redirect_to: "https://wachter-space.de/2021/11/16/asis_ctf_2021_writeup#factory"
 categories: writeups
 ---
 

--- a/_posts/2021-11-16-gesture.md
+++ b/_posts/2021-11-16-gesture.md
@@ -1,6 +1,6 @@
 ---
 title: "ASIS CTF 2021: Gesture"
-external_url: "https://wachter-space.de/2021/11/16/asis_ctf_2021_writeup#gesture"
+redirect_to: "https://wachter-space.de/2021/11/16/asis_ctf_2021_writeup#gesture"
 categories: writeups
 ---
 

--- a/_posts/2021-11-16-madras.md
+++ b/_posts/2021-11-16-madras.md
@@ -1,6 +1,6 @@
 ---
 title: "ASIS CTF 2021: Madras"
-external_url: "https://wachter-space.de/2021/11/16/asis_ctf_2021_writeup#madras"
+redirect_to: "https://wachter-space.de/2021/11/16/asis_ctf_2021_writeup#madras"
 categories: writeups
 ---
 

--- a/_posts/2021-11-17-pycoin.md
+++ b/_posts/2021-11-17-pycoin.md
@@ -1,6 +1,6 @@
 ---
 title: "hack.lu CTF 2021: PYCOIN"
-external_url: "https://wachter-space.de/2021/11/17/hacklu_ctf_2021_writeup#pycoin"
+redirect_to: "https://wachter-space.de/2021/11/17/hacklu_ctf_2021_writeup#pycoin"
 categories: writeups
 ---
 

--- a/_posts/2021-11-17-touchy_logger.md
+++ b/_posts/2021-11-17-touchy_logger.md
@@ -1,6 +1,6 @@
 ---
 title: "hack.lu CTF 2021: Touchy Logger"
-external_url: "https://wachter-space.de/2021/11/17/hacklu_ctf_2021_writeup#touchy-logger"
+redirect_to: "https://wachter-space.de/2021/11/17/hacklu_ctf_2021_writeup#touchy-logger"
 categories: writeups
 ---
 

--- a/_posts/2021-11-30-csrunner.md
+++ b/_posts/2021-11-30-csrunner.md
@@ -1,6 +1,6 @@
 ---
 title: "Cyber Security Rumble 2021: CSRunner"
-external_url: "https://blog.martinwagner.co/rumble/#csrunner"
+redirect_to: "https://blog.martinwagner.co/rumble/#csrunner"
 categories: writeups
 ---
 

--- a/_posts/2021-11-30-follow_the_leader.md
+++ b/_posts/2021-11-30-follow_the_leader.md
@@ -1,6 +1,6 @@
 ---
 title: "Cyber Security Rumble 2021: FollowTheLeader"
-external_url: "https://blog.martinwagner.co/rumble/#followtheleader"
+redirect_to: "https://blog.martinwagner.co/rumble/#followtheleader"
 categories: writeups
 ---
 

--- a/_posts/2021-11-30-unaffordable.md
+++ b/_posts/2021-11-30-unaffordable.md
@@ -1,6 +1,6 @@
 ---
 title: "Cyber Security Rumble 2021: Unaffordable"
-external_url: "https://blog.martinwagner.co/rumble/#unaffordable"
+redirect_to: "https://blog.martinwagner.co/rumble/#unaffordable"
 categories: writeups
 ---
 

--- a/_posts/2021-11-30-unknown_origin.md
+++ b/_posts/2021-11-30-unknown_origin.md
@@ -1,6 +1,6 @@
 ---
 title: "Cyber Security Rumble 2021: UnknownOrigin"
-external_url: "https://blog.martinwagner.co/rumble/#unknownorigin"
+redirect_to: "https://blog.martinwagner.co/rumble/#unknownorigin"
 categories: writeups
 ---
 

--- a/_posts/2021-12-19-shitty_blog.md
+++ b/_posts/2021-12-19-shitty_blog.md
@@ -1,6 +1,6 @@
 ---
 title: "hxp CTF 2021: Shitty Blog"
-external_url: "https://wachter-space.de/2021/12/19/hxp_21"
+redirect_to: "https://wachter-space.de/2021/12/19/hxp_21"
 categories: writeups
 ---
 

--- a/_posts/2022-01-31-herald.md
+++ b/_posts/2022-01-31-herald.md
@@ -1,6 +1,6 @@
 ---
 title: "Insomnihack Teaser 2022: Herald"
-external_url: "https://wachter-space.de/2022/01/31/insteaser22"
+redirect_to: "https://wachter-space.de/2022/01/31/insteaser22"
 categories: writeups
 ---
 

--- a/_posts/2022-04-25-resnet.md
+++ b/_posts/2022-04-25-resnet.md
@@ -1,6 +1,6 @@
 ---
 title: "b01lers CTF 2022: resnet Model Inversion"
-external_url: "https://wachter-space.de/2022/04/25/ctf_model_inversion_writeup/"
+redirect_to: "https://wachter-space.de/2022/04/25/ctf_model_inversion_writeup/"
 categories: writeups
 ---
 

--- a/_posts/2022-12-25-v8-date.md
+++ b/_posts/2022-12-25-v8-date.md
@@ -1,5 +1,5 @@
 ---
 title: "KITCTFCTF 2022 V8 Heap Sandbox Escape"
-external_url: "https://blog.ju256.de/posts/kitctfctf22-date/"
+redirect_to: "https://blog.ju256.de/posts/kitctfctf22-date/"
 categories: writeups
 ---

--- a/_posts/2023-02-10-dicectf2023-parallelism_and_not-baby-parallelism.md
+++ b/_posts/2023-02-10-dicectf2023-parallelism_and_not-baby-parallelism.md
@@ -1,5 +1,5 @@
 ---
 title: "DiceCTF 2023: parallelism and not-baby-parallelism writeup"
-external_url: "https://ik0ri4n.de/dice-ctf-23"
+redirect_to: "https://ik0ri4n.de/dice-ctf-23"
 categories: writeups
 ---

--- a/_posts/2023-02-10-slots.md
+++ b/_posts/2023-02-10-slots.md
@@ -1,5 +1,5 @@
 ---
 title: "KITCTFCTF 2022 Slots Writeup"
-external_url: "https://ik0ri4n.de/kitctfctf-22-slots"
+redirect_to: "https://ik0ri4n.de/kitctfctf-22-slots"
 categories: writeups
 ---

--- a/_posts/2023-04-11-tex-based-adventure.md
+++ b/_posts/2023-04-11-tex-based-adventure.md
@@ -1,5 +1,5 @@
 ---
 title: "hxp CTF 2022 tex_based_adventure: Post-CTF writeup"
-external_url: "https://ik0ri4n.de/hxp-ctf-22-tex-based-adventure"
+redirect_to: "https://ik0ri4n.de/hxp-ctf-22-tex-based-adventure"
 categories: writeups
 ---

--- a/index.html
+++ b/index.html
@@ -33,10 +33,10 @@ layout: default
       {% endfor %}
       {% unless sticky %}
       {% unless learning %}
-      {% if post.external_url %}
+      {% if post.redirect_to %}
       <li>
         <span class="post-date">{{ post.date | date: "%b %-d, %Y" }}</span>
-        <a class="post-link" href="{{ post.external_url }}">{{ post.title }}</a>
+        <a class="post-link" href="{{ post.redirect_to }}">{{ post.title }}</a>
       </li>
       {% else %}
       <li>


### PR DESCRIPTION
If we had a post like:
```
$ cat foo.md
---
title: Foo
external_url: example.org/
---
```
then visiting kitctf.de/foo would not redirect to `external_url`. (The html of kitctf.de/foo is empty!)
This is a problem when using an RSS reader, because it uses kitctf.de/foo as post url and not the external url.
These redirects were only applied when **listing** the pages in https://github.com/kitctf/www/blob/dfaf4a49d2f4a2813ca80ee6cd41c2de1e13a8a3/_layouts/category_index.html#L22 and https://github.com/kitctf/www/blob/dfaf4a49d2f4a2813ca80ee6cd41c2de1e13a8a3/index.html#L36 .

We now use `jekyll-redirect-from` so that kitctf.de/foo has a redirect in its html. When listing the pages, we keep directly linking to the external url, so that we don't do an unnecessary redirect (kitctf.de/ -> **kitctf.de/foo** (<-unnecessary) -> example.org).