### PR TITLE
Use redirect_url in RSS feed if defined

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -14,7 +14,11 @@ layout: none
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
+      {% if post.redirect_to %}
+        <link>{{ post.redirect_to }}</link>
+      {% else %}
         <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
+      {% endif %}
         <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
       </item>
     {% endfor %}


### PR DESCRIPTION
Adds a bit of logic to publish the external URL to the feed if it is defined.

For an even better experience, we should add a description to all external posts on our site as the feed reader and our homepage do look a bit empty without a description.